### PR TITLE
27 Recruiter Page- Live Career Fair w/ Students in Queue Component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10514,6 +10514,14 @@
         "warning": "^4.0.3"
       }
     },
+    "react-countdown": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-countdown/-/react-countdown-2.3.1.tgz",
+      "integrity": "sha512-h66prF+Wwj3Ru4tDeqvXsW8iqaCyC54pjwTAlUUmUQ11EUqIO34xV4pO4q8MGT6917ep47ntKmBW99ZVN1ozdQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.5.3",
     "react": "^16.13.1",
     "react-bootstrap": "^1.4.0",
+    "react-countdown": "^2.3.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1"

--- a/client/src/Main.js
+++ b/client/src/Main.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Route, Switch, withRouter } from "react-router-dom";
-import { StudentProfilePage, HomePage, SearchResultsPage, RouteNotFound, StudentLivePage, RecruiterProfilePage, ManageFairPage, CreateFairPage, OrganizerPage, LoginPage, RecruiterAddEditBoothPage } from "./Pages";
+import { StudentProfilePage, HomePage, SearchResultsPage, RouteNotFound, StudentLivePage, RecruiterProfilePage, ManageFairPage, CreateFairPage, OrganizerPage, LoginPage, RecruiterAddEditBoothPage, RecruiterLivePage } from "./Pages";
 
 import { Navbar, Nav, Form, FormControl, Button } from "react-bootstrap";
 
@@ -64,6 +64,7 @@ class Main extends React.Component {
           <Route exact path="/studentlive" component={StudentLivePage} />
           <Route exact path="/recruiter" component={RecruiterProfilePage} />
           <Route exact path="/add-edit-booth" component={RecruiterAddEditBoothPage} />
+          <Route exact path="/recruiter-live" component={RecruiterLivePage} />
           <Route component={RouteNotFound} />
         </Switch>
       </>

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -1,15 +1,6 @@
 import React from "react";
-import {Card, CardDeck, Button} from "react-bootstrap";
-import google from '../Images/google.jpg'; 
-import microsoft from '../Images/microsoft.jpg'; 
-import facebook from '../Images/facebook.jpg'; 
-import apple from '../Images/apple.jpg'; 
-import tesla from '../Images/tesla.jpg'; 
-import snapchat from '../Images/snapchat.jpg'; 
-import qualcomm from '../Images/qualcomm.jpg'; 
-import paypal from '../Images/paypal.jpg'; 
-import netflix from '../Images/netflix.jpg'; 
-import {MoreInfo} from './MoreInfo'
+import {Card, CardDeck, Button, Image} from "react-bootstrap";
+import profile from '../Images/profile.jpg'; 
 
 export default class RecruiterLivePage extends React.Component {
     handleRoute = route => () => {
@@ -18,81 +9,88 @@ export default class RecruiterLivePage extends React.Component {
   render() {
     return (
       <div style={{padding: "20px", "text-align": "center"}}>
-        <Card style={{"padding": "20px"}}>
+        <Card style={{"padding": "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
             <h3><b>Live Career Fair:</b> UCLA Engineering Tech Fair</h3>
             <h6>Students in queue for Google full-time software engineering roles.</h6>
         </Card>
-        <Card style={{padding: "20px"}}>
+        <br></br>
+        <Card style={{padding: "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
             <Card>
                 <Card.Header as="h5">Position 1</Card.Header>
                 <Card.Body>
-                    <Card.Title>Denise Wang</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Denise Wang</Card.Title>
                     <Card.Text>
-                    Student bio if they have one: 
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-success">Join Now</Button>
+                    <Button size="sm" variant="outline-success" href="https://meet.google.com/ezb-yrqf-vsq">Join Now</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
                 <Card.Header as="h5">Position 2</Card.Header>
                 <Card.Body>
-                    <Card.Title>Siddharth Joshi</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Siddharth Joshi</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-dark">Position 2</Button>
+                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 2</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
                 <Card.Header as="h5">Position 3</Card.Header>
                 <Card.Body>
-                    <Card.Title>Arnav Garg</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Arnav Garg</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-dark">Position 3</Button>
+                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 3</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
                 <Card.Header as="h5">Position 4</Card.Header>
                 <Card.Body>
-                    <Card.Title>Yingge Zhou</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Yingge Zhou</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-dark">Position 4</Button>
+                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 4</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
                 <Card.Header as="h5">Position 5</Card.Header>
                 <Card.Body>
-                    <Card.Title>Gautam Nambiar</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Gautam Nambiar</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-dark">Position 5</Button>
+                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 5</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
                 <Card.Header as="h5">Position 6</Card.Header>
                 <Card.Body>
-                    <Card.Title>Jayant Mehra</Card.Title>
+                    <Image src={profile} rounded height="150px"/>
+                    <Card.Title style={{"margin-top": "10px"}}>Jayant Mehra</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one.
                     </Card.Text>
-                    <Button size="sm" variant="outline-dark">Position 6</Button>
+                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 6</Button>
                     &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark">View Resume</Button>
+                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
             </Card>
         </Card>

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -1,6 +1,8 @@
 import React from "react";
-import {Card, CardDeck, Button, Image, Table, Form} from "react-bootstrap";
-import profile from '../Images/profile.jpg'; 
+import {Card, Button, Image, Table, Form} from "react-bootstrap";
+import Countdown from "react-countdown";
+
+const Completionist = () => <span>Career fair ended.</span>;
 
 export default class RecruiterLivePage extends React.Component {
     handleRoute = route => () => {
@@ -12,6 +14,11 @@ export default class RecruiterLivePage extends React.Component {
         <Card style={{"padding": "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
             <h3><b>Live Career Fair:</b> UCLA Engineering Tech Fair</h3>
             <h6>Students in queue for Google full-time software engineering roles.</h6>
+            <h1>
+            <Countdown date={Date.now() + 500000000}>
+                <Completionist />
+            </Countdown>
+            </h1>
         </Card>
         <br></br>
         <Card style={{padding: "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -17,8 +17,69 @@ export default class RecruiterLivePage extends React.Component {
         };
   render() {
     return (
-      <div style={{ "text-align": "center", "margin": "20px 20px" }}>
-          HELLO?!?!?! DOES THIS WORK?!?!
+      <div style={{padding: "20px", "text-align": "center"}}>
+        <Card style={{padding: "20px"}}>
+            <Card>
+                <Card.Header as="h5">Position 1</Card.Header>
+                <Card.Body>
+                    <Card.Title>Denise Wang</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+            <Card>
+                <Card.Header as="h5">Position 2</Card.Header>
+                <Card.Body>
+                    <Card.Title>Siddharth Joshi</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+            <Card>
+                <Card.Header as="h5">Position 3</Card.Header>
+                <Card.Body>
+                    <Card.Title>Arnav Garg</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+            <Card>
+                <Card.Header as="h5">Position 4</Card.Header>
+                <Card.Body>
+                    <Card.Title>Yingge Zhou</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+            <Card>
+                <Card.Header as="h5">Position 5</Card.Header>
+                <Card.Body>
+                    <Card.Title>Gautam Nambiar</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+            <Card>
+                <Card.Header as="h5">Position 6</Card.Header>
+                <Card.Body>
+                    <Card.Title>Jayant Mehra</Card.Title>
+                    <Card.Text>
+                    With supporting text below as a natural lead-in to additional content.
+                    </Card.Text>
+                    <Button variant="outline-dark">Go somewhere</Button>
+                </Card.Body>
+            </Card>
+        </Card>
       </div>
     );
   }

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {Card, CardDeck, Button, Image} from "react-bootstrap";
+import {Card, CardDeck, Button, Image, Table, Form} from "react-bootstrap";
 import profile from '../Images/profile.jpg'; 
 
 export default class RecruiterLivePage extends React.Component {
@@ -15,7 +15,78 @@ export default class RecruiterLivePage extends React.Component {
         </Card>
         <br></br>
         <Card style={{padding: "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
-            <Card>
+            <h3>Notes for student applicants.</h3>
+            <p></p>
+            <Table striped bordered hover>
+                <thead>
+                    <tr>
+                    <th>Name</th>
+                    <th>Interests</th>
+                    <th style={{"width": "40%"}}>Notes</th>
+                    <th>Resume</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                    <td>Denise Wang</td>
+                    <td>Full-time software engineering (frontend)</td>
+                    <td>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                    <tr>
+                    <td>Siddharth Joshi</td>
+                    <td>Full-time software engineering (backend)</td>
+                    <td>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                    <tr>
+                    <td>Arnav Garg</td>
+                    <td>Full-time software engineering (backend)</td>
+                    <td>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                    <tr>
+                    <td>Denise Wang</td>
+                    <td>Full-time software engineering (frontend)</td>
+                    <td>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                    <tr>
+                    <td>Siddharth Joshi</td>
+                    <td>Full-time software engineering (backend)</td>
+                    <td>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                    <tr>
+                    <td>Arnav Garg</td>
+                    <td>
+                        <Form.Group controlId="exampleForm.ControlTextarea1">
+                            <Form.Control as="textarea" rows={3} />
+                        </Form.Group>
+                        <Button size="sm" variant="outline-dark">Save</Button>        
+                    </td>
+                    <td>
+                        <Form.Group controlId="exampleForm.ControlTextarea1">
+                            <Form.Control as="textarea" rows={3} />
+                        </Form.Group>
+                        <Button size="sm" variant="outline-dark">Save</Button>
+                    </td>
+                    <td><Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button></td>
+                    </tr>
+                </tbody>
+            </Table>
+
+            {/* <Card>
                 <Card.Header as="h5">Position 1</Card.Header>
                 <Card.Body>
                     <Image src={profile} rounded height="150px"/>
@@ -92,7 +163,7 @@ export default class RecruiterLivePage extends React.Component {
                     &nbsp;&nbsp;&nbsp;&nbsp;
                     <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
                 </Card.Body>
-            </Card>
+            </Card> */}
         </Card>
       </div>
     );

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -12,13 +12,30 @@ export default class RecruiterLivePage extends React.Component {
     return (
       <div style={{padding: "20px", "text-align": "center"}}>
         <Card style={{"padding": "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
-            <h3><b>Live Career Fair:</b> UCLA Engineering Tech Fair</h3>
-            <h6>Students in queue for Google full-time software engineering roles.</h6>
-            <h1>
-            <Countdown date={Date.now() + 500000000}>
-                <Completionist />
-            </Countdown>
-            </h1>
+            <h2><b>Live Career Fair:</b> UCLA Engineering Tech Fair</h2>
+            <h5>Students in queue for Google full-time software engineering roles.</h5>
+        </Card>
+        <br></br>
+        <Card style={{"padding": "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
+            <h4>
+                <b>Time left in career fair:</b>
+            </h4>
+            <h5>
+                <Countdown date={Date.now() + 500000000}>
+                    <Completionist />
+                </Countdown>
+            </h5>
+            <h6></h6>
+            <h4>
+                <b>Students remaining in queue:</b>
+            </h4>
+            <h5> 4 students</h5>
+            <h6></h6>
+            <h4>
+                <b>Join next meeting:</b>
+                <h6></h6>
+                <Button size="sm" variant="outline-success" href="https://meet.google.com/ezb-yrqf-vsq">Join Now</Button>
+            </h4>
         </Card>
         <br></br>
         <Card style={{padding: "20px", "box-shadow": "8px 4px 8px 4px rgba(0,0,0,0.2)"}}>
@@ -92,85 +109,6 @@ export default class RecruiterLivePage extends React.Component {
                     </tr>
                 </tbody>
             </Table>
-
-            {/* <Card>
-                <Card.Header as="h5">Position 1</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Denise Wang</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-success" href="https://meet.google.com/ezb-yrqf-vsq">Join Now</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card>
-            <Card>
-                <Card.Header as="h5">Position 2</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Siddharth Joshi</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 2</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card>
-            <Card>
-                <Card.Header as="h5">Position 3</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Arnav Garg</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 3</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card>
-            <Card>
-                <Card.Header as="h5">Position 4</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Yingge Zhou</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 4</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card>
-            <Card>
-                <Card.Header as="h5">Position 5</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Gautam Nambiar</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 5</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card>
-            <Card>
-                <Card.Header as="h5">Position 6</Card.Header>
-                <Card.Body>
-                    <Image src={profile} rounded height="150px"/>
-                    <Card.Title style={{"margin-top": "10px"}}>Jayant Mehra</Card.Title>
-                    <Card.Text>
-                    Student bio if they have one.
-                    </Card.Text>
-                    <Button size="sm" variant="outline-secondary" disabled style={{ pointerEvents: 'none' }}>Position 6</Button>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    <Button size="sm" variant="outline-dark" href="https://writing.colostate.edu/guides/documents/resume/functionalSample.pdf">View Resume</Button>
-                </Card.Body>
-            </Card> */}
         </Card>
       </div>
     );

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -18,15 +18,21 @@ export default class RecruiterLivePage extends React.Component {
   render() {
     return (
       <div style={{padding: "20px", "text-align": "center"}}>
+        <Card style={{"padding": "20px"}}>
+            <h3><b>Live Career Fair:</b> UCLA Engineering Tech Fair</h3>
+            <h6>Students in queue for Google full-time software engineering roles.</h6>
+        </Card>
         <Card style={{padding: "20px"}}>
             <Card>
                 <Card.Header as="h5">Position 1</Card.Header>
                 <Card.Body>
                     <Card.Title>Denise Wang</Card.Title>
                     <Card.Text>
-                    With supporting text below as a natural lead-in to additional content.
+                    Student bio if they have one: 
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-success">Join Now</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
@@ -36,7 +42,9 @@ export default class RecruiterLivePage extends React.Component {
                     <Card.Text>
                     With supporting text below as a natural lead-in to additional content.
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-dark">Position 2</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
@@ -46,7 +54,9 @@ export default class RecruiterLivePage extends React.Component {
                     <Card.Text>
                     With supporting text below as a natural lead-in to additional content.
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-dark">Position 3</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
@@ -56,7 +66,9 @@ export default class RecruiterLivePage extends React.Component {
                     <Card.Text>
                     With supporting text below as a natural lead-in to additional content.
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-dark">Position 4</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
@@ -66,7 +78,9 @@ export default class RecruiterLivePage extends React.Component {
                     <Card.Text>
                     With supporting text below as a natural lead-in to additional content.
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-dark">Position 5</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
             <Card>
@@ -76,7 +90,9 @@ export default class RecruiterLivePage extends React.Component {
                     <Card.Text>
                     With supporting text below as a natural lead-in to additional content.
                     </Card.Text>
-                    <Button variant="outline-dark">Go somewhere</Button>
+                    <Button size="sm" variant="outline-dark">Position 6</Button>
+                    &nbsp;&nbsp;&nbsp;&nbsp;
+                    <Button size="sm" variant="outline-dark">View Resume</Button>
                 </Card.Body>
             </Card>
         </Card>

--- a/client/src/Pages/RecruiterLivePage.js
+++ b/client/src/Pages/RecruiterLivePage.js
@@ -1,0 +1,25 @@
+import React from "react";
+import {Card, CardDeck, Button} from "react-bootstrap";
+import google from '../Images/google.jpg'; 
+import microsoft from '../Images/microsoft.jpg'; 
+import facebook from '../Images/facebook.jpg'; 
+import apple from '../Images/apple.jpg'; 
+import tesla from '../Images/tesla.jpg'; 
+import snapchat from '../Images/snapchat.jpg'; 
+import qualcomm from '../Images/qualcomm.jpg'; 
+import paypal from '../Images/paypal.jpg'; 
+import netflix from '../Images/netflix.jpg'; 
+import {MoreInfo} from './MoreInfo'
+
+export default class RecruiterLivePage extends React.Component {
+    handleRoute = route => () => {
+        this.props.history.push({ pathname: route });
+        };
+  render() {
+    return (
+      <div style={{ "text-align": "center", "margin": "20px 20px" }}>
+          HELLO?!?!?! DOES THIS WORK?!?!
+      </div>
+    );
+  }
+}

--- a/client/src/Pages/RecruiterProfilePage.js
+++ b/client/src/Pages/RecruiterProfilePage.js
@@ -34,7 +34,7 @@ export default class RecruiterProfilePage extends React.Component {
             <Card.Text>
             October 21, 2020 from 11AM-2PM PST
             </Card.Text>
-            <Button variant="outline-success">Join Now</Button>
+            <Button variant="outline-success" onClick={this.handleRoute("/recruiter-live")}>Join Now</Button>
         </Card.Body>
         </Card>
         </div>

--- a/client/src/Pages/index.js
+++ b/client/src/Pages/index.js
@@ -9,7 +9,8 @@ import SearchResultsPage from "./SearchResultsPage";
 import RecruiterProfilePage from "./RecruiterProfilePage";
 import RecruiterAddEditBoothPage from "./RecruiterAddEditBoothPage"
 import RouteNotFound from "./RouteNotFound";
+import RecruiterLivePage from "./RecruiterLivePage"
 
 
-export { StudentProfilePage, HomePage, SearchResultsPage, RouteNotFound, StudentLivePage, RecruiterProfilePage, ManageFairPage, CreateFairPage, OrganizerPage, LoginPage, RecruiterAddEditBoothPage };
+export { StudentProfilePage, HomePage, SearchResultsPage, RouteNotFound, StudentLivePage, RecruiterProfilePage, ManageFairPage, CreateFairPage, OrganizerPage, LoginPage, RecruiterAddEditBoothPage, RecruiterLivePage };
 


### PR DESCRIPTION
issue #27 recruiter page- live career fair w/ students in queue component
- added the live career fair page for recruiters
- this page includes the queue where students are waiting to meet with recruiter
- recruiter are able to join a meeting with a students and also view their resume/basic profile
- you can get to this page from the home page by clicking "get started" for recruiters, and then "join now" on the live career fairs section

for visual approval:

before considering backend feasibility:
![27-recruiterpage](https://user-images.githubusercontent.com/42252682/98644551-7f16fc00-22e5-11eb-9844-52872c245108.gif)

after considering backend feasibility:
![27-recruiterpage-2](https://user-images.githubusercontent.com/42252682/98711460-dba40680-2339-11eb-9eb1-3042396f2a22.gif)

