### PR TITLE
58 Student Page- Redo Components w/ Live, Upcoming (Registered/Not Registered), Past Fairs

### DIFF
--- a/client/src/Pages/StudentProfilePage.js
+++ b/client/src/Pages/StudentProfilePage.js
@@ -84,6 +84,46 @@ export default class StudentProfilePage extends React.Component {
                 </CardGroup>
             </Card>
             </div>
+            <div style={{"padding": "20px", "color": "black"}}>
+                <Card style={{"padding": "20px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)" }}>
+                <Card.Header><h2><b>Upcoming Career Fairs (Not Registered)</b></h2></Card.Header>
+                    <CardGroup style={{ "width": "100%", "padding": "0 20px 20px 20px", "padding-top": "20px"}}>
+                        <Card style={{ "padding-bottom": "5px"}}>
+                            <Card.Header><h3>Career Fair #5</h3></Card.Header>
+                            <Card.Body>
+                            <Card.Title><b>Status: </b>Not Registered</Card.Title>
+                            <Card.Text>
+                                <p><b>Date: </b>Thursday, November 5, 2020</p>
+                                <p><b>Time: </b> 11 PST - 3PM PST</p>
+                                <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                            </Card.Text>
+                            </Card.Body>
+                        </Card>
+                        <Card>
+                            <Card.Header><h3>Career Fair #6</h3></Card.Header>
+                            <Card.Body>
+                            <Card.Title><b>Status: </b> Not Registered</Card.Title>
+                            <Card.Text>
+                                <p><b>Date: </b>Wednesday, November 11, 2020</p>
+                                <p><b>Time: </b> 11AM PST - 5PM PST</p>
+                                <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                            </Card.Text>
+                            </Card.Body>
+                        </Card>
+                        <Card>
+                            <Card.Header><h3>Career Fair #7</h3></Card.Header>
+                            <Card.Body>
+                            <Card.Title><b>Status: </b> Not Registered</Card.Title>
+                            <Card.Text>
+                                <p><b>Date: </b>Tuesday, November 17, 2020</p>
+                                <p><b>Time: </b>10AM PST - 3PM PST</p>
+                                <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                            </Card.Text>
+                            </Card.Body>
+                        </Card>
+                    </CardGroup>
+                </Card>
+            </div>
       </div>
     );
   }

--- a/client/src/Pages/StudentProfilePage.js
+++ b/client/src/Pages/StudentProfilePage.js
@@ -124,6 +124,46 @@ export default class StudentProfilePage extends React.Component {
                     </CardGroup>
                 </Card>
             </div>
+            <div style={{"padding": "20px", "color": "black"}}>
+            <Card style={{"padding": "20px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)" }}>
+            <Card.Header><h2><b>Past Career Fairs</b></h2></Card.Header>
+                <CardGroup style={{ "width": "100%", "padding": "0 20px 20px 20px", "padding-top": "20px"}}>
+                    <Card style={{ "padding-bottom": "5px"}}>
+                        <Card.Header><h3>Career Fair #8</h3></Card.Header>
+                        <Card.Body>
+                        <Card.Title><b>Status: </b>Attended</Card.Title>
+                        <Card.Text>
+                            <p><b>Date: </b>Thursday, November 5, 2020</p>
+                            <p><b>Time: </b> 11 PST - 3PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                        </Card.Text>
+                        </Card.Body>
+                    </Card>
+                    <Card>
+                        <Card.Header><h3>Career Fair #9</h3></Card.Header>
+                        <Card.Body>
+                        <Card.Title><b>Status: </b>Attended</Card.Title>
+                        <Card.Text>
+                            <p><b>Date: </b>Wednesday, November 11, 2020</p>
+                            <p><b>Time: </b> 11AM PST - 5PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                        </Card.Text>
+                        </Card.Body>
+                    </Card>
+                    <Card>
+                        <Card.Header><h3>Career Fair #10</h3></Card.Header>
+                        <Card.Body>
+                        <Card.Title><b>Status: </b>Attended</Card.Title>
+                        <Card.Text>
+                            <p><b>Date: </b>Tuesday, November 17, 2020</p>
+                            <p><b>Time: </b>10AM PST - 3PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Fair</Button>
+                        </Card.Text>
+                        </Card.Body>
+                    </Card>
+                </CardGroup>
+            </Card>
+            </div>
       </div>
     );
   }

--- a/client/src/Pages/StudentProfilePage.js
+++ b/client/src/Pages/StudentProfilePage.js
@@ -27,49 +27,27 @@ export default class StudentProfilePage extends React.Component {
                 {/* <Card.Footer className="text-muted">2 days ago</Card.Footer> */}
             </Card>
         </div>
-                <CardGroup style={{ "width": "100%", "padding": "20px 20px 0 20px"}}>
-                    <Card style={{ "padding-bottom": "10px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}} >
-                    <div style={{ "color": "black"}}>
+        <div style={{"padding": "20px", "color": "black"}}>
+            <Card style={{"padding": "20px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)" }}>
+               <Card.Header><h2><b>Live Career Fairs</b></h2></Card.Header>
+                <p></p>
+                    <Card style={{ "padding-bottom": "10px", "width": "50%", "margin": "auto"}} >
                         <Card.Header><h3>Career Fair #1</h3></Card.Header>
                         <Card.Body>
                         <Card.Title><b>Status: </b> Registered</Card.Title>
                         <Card.Text>
                             <p><b>Date: </b>Today, October 25, 2020</p>
                             <p><b>Time: </b>Live Now, 11 PST - 3PM PST</p>
+                            <Button onClick={this.handleRoute("/studentlive")} variant="outline-success">Join Now</Button>
                         </Card.Text>
                         </Card.Body>
-                        <Button onClick={this.handleRoute("/studentlive")} variant="outline-danger">Join Now</Button>
-                    </div>
                     </Card>
-                    <Card style={{"box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}}>
-                    <div style={{ "color": "black"}}>
-                        <Card.Header><h3>Career Fair #2</h3></Card.Header>
-                        <Card.Body>
-                        <Card.Title><b>Status: </b> Registered</Card.Title>
-                        <Card.Text>
-                            <p><b>Date: </b>Monday, October 26, 2020</p>
-                            <p><b>Time: </b> 11AM PST - 5PM PST</p>
-                        </Card.Text>
-                        </Card.Body>
-                        <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>Event Details</Button>
-                    </div>
-                    </Card>
-                    <Card style={{"box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}}>
-                    <div style={{ "color": "black"}}>
-                        <Card.Header><h3>Career Fair #3</h3></Card.Header>
-                        <Card.Body>
-                        <Card.Title><b>Status: </b> Not Registered</Card.Title>
-                        <Card.Text>
-                            <p><b>Date: </b>Tuesday, October 27, 2020</p>
-                            <p><b>Time: </b>10AM PST - 3PM PST</p>
-                        </Card.Text>
-                        </Card.Body>
-                        <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
-                    </div>
-                    </Card>
-                </CardGroup>
+            </Card>
+        </div>
+        <div style={{"padding": "20px", "color": "black"}}>
+            <Card style={{"padding": "20px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)" }}>
                 <CardGroup style={{ "width": "100%", "padding": "0 20px 20px 20px"}}>
-                    <Card style={{ "padding-bottom": "10px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}}>
+                    <Card>
                     <div style={{ "color": "black"}}>
                         <Card.Header><h3>Career Fair #4</h3></Card.Header>
                         <Card.Body>
@@ -82,7 +60,7 @@ export default class StudentProfilePage extends React.Component {
                         <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
                     </div>
                     </Card>
-                    <Card style={{"box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}}>
+                    <Card>
                     <div style={{ "color": "black"}}>
                         <Card.Header><h3>Career Fair #5</h3></Card.Header>
                         <Card.Body>
@@ -95,7 +73,7 @@ export default class StudentProfilePage extends React.Component {
                         <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
                     </div>
                     </Card>
-                    <Card style={{"box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)"}}>
+                    <Card>
                     <div style={{ "color": "black"}}>
                         <Card.Header><h3>Career Fair #6</h3></Card.Header>
                         <Card.Body>
@@ -109,6 +87,8 @@ export default class StudentProfilePage extends React.Component {
                     </div>
                     </Card>
                 </CardGroup>
+            </Card>
+            </div>
       </div>
     );
   }

--- a/client/src/Pages/StudentProfilePage.js
+++ b/client/src/Pages/StudentProfilePage.js
@@ -46,45 +46,40 @@ export default class StudentProfilePage extends React.Component {
         </div>
         <div style={{"padding": "20px", "color": "black"}}>
             <Card style={{"padding": "20px", "box-shadow": "0 4px 8px 0 rgba(0,0,0,0.2)" }}>
-                <CardGroup style={{ "width": "100%", "padding": "0 20px 20px 20px"}}>
-                    <Card>
-                    <div style={{ "color": "black"}}>
-                        <Card.Header><h3>Career Fair #4</h3></Card.Header>
+            <Card.Header><h2><b>Upcoming Career Fairs (Registered)</b></h2></Card.Header>
+                <CardGroup style={{ "width": "100%", "padding": "0 20px 20px 20px", "padding-top": "20px"}}>
+                    <Card style={{ "padding-bottom": "5px"}}>
+                        <Card.Header><h3>Career Fair #2</h3></Card.Header>
                         <Card.Body>
-                        <Card.Title><b>Status: </b>Not Registered</Card.Title>
+                        <Card.Title><b>Status: </b>Registered</Card.Title>
                         <Card.Text>
                             <p><b>Date: </b>Thursday, November 5, 2020</p>
                             <p><b>Time: </b> 11 PST - 3PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Details</Button>
                         </Card.Text>
                         </Card.Body>
-                        <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
-                    </div>
                     </Card>
                     <Card>
-                    <div style={{ "color": "black"}}>
-                        <Card.Header><h3>Career Fair #5</h3></Card.Header>
+                        <Card.Header><h3>Career Fair #3</h3></Card.Header>
                         <Card.Body>
-                        <Card.Title><b>Status: </b> Not Registered</Card.Title>
+                        <Card.Title><b>Status: </b>Registered</Card.Title>
                         <Card.Text>
                             <p><b>Date: </b>Wednesday, November 11, 2020</p>
                             <p><b>Time: </b> 11AM PST - 5PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Details</Button>
                         </Card.Text>
                         </Card.Body>
-                        <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
-                    </div>
                     </Card>
                     <Card>
-                    <div style={{ "color": "black"}}>
-                        <Card.Header><h3>Career Fair #6</h3></Card.Header>
+                        <Card.Header><h3>Career Fair #4</h3></Card.Header>
                         <Card.Body>
-                        <Card.Title><b>Status: </b> Not Registered</Card.Title>
+                        <Card.Title><b>Status: </b>Registered</Card.Title>
                         <Card.Text>
                             <p><b>Date: </b>Tuesday, November 17, 2020</p>
                             <p><b>Time: </b>10AM PST - 3PM PST</p>
+                            <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Details</Button>
                         </Card.Text>
                         </Card.Body>
-                        <Button variant="outline-dark" onClick={this.handleRoute("/student-upcoming")}>View Event</Button>
-                    </div>
                     </Card>
                 </CardGroup>
             </Card>


### PR DESCRIPTION
- redid the student profile page with live, upcoming (registered/not registered), and past career fairs 
- easier to distinguish between upcoming (registered/not registered) and past fairs

before:
![24-studentpage](https://user-images.githubusercontent.com/42252682/98901390-93cfcd00-2468-11eb-9389-5dc1a98cc035.gif)

after:
![58-studentpage](https://user-images.githubusercontent.com/42252682/98901578-db565900-2468-11eb-9e0f-924749b0fedb.gif)

